### PR TITLE
Fix timestamp assignment in epoch processing

### DIFF
--- a/course/module3/04_3d_timeseries_analysis/04_3d_timeseries_analysis.ipynb
+++ b/course/module3/04_3d_timeseries_analysis/04_3d_timeseries_analysis.ipynb
@@ -445,6 +445,8 @@
    "source": [
     "# create a list to collect epoch objects\n",
     "epochs = []\n",
+    "# start from pc_list[1:] to skip the reference epoch\n",
+    "# since enumerate starts from 0, use timestamps[e+1] to match the epochs with their timestamps\n",
     "for e, pc_file in enumerate(pc_list[1:]):\n",
     "    epoch_file = os.path.join(pc_dir, pc_file)\n",
     "    epoch = py4dgeo.read_from_las(epoch_file)\n",

--- a/course/module3/04_3d_timeseries_analysis/04_3d_timeseries_analysis.ipynb
+++ b/course/module3/04_3d_timeseries_analysis/04_3d_timeseries_analysis.ipynb
@@ -448,7 +448,7 @@
     "for e, pc_file in enumerate(pc_list[1:]):\n",
     "    epoch_file = os.path.join(pc_dir, pc_file)\n",
     "    epoch = py4dgeo.read_from_las(epoch_file)\n",
-    "    epoch.timestamp = timestamps[e]\n",
+    "    epoch.timestamp = timestamps[e+1]\n",
     "    epochs.append(epoch)\n",
     "\n",
     "# add epoch objects to the spatiotemporal analysis object\n",

--- a/course/module3/04_3d_timeseries_analysis/exercise/m3_theme4_exercise1_solution1.ipynb
+++ b/course/module3/04_3d_timeseries_analysis/exercise/m3_theme4_exercise1_solution1.ipynb
@@ -242,6 +242,8 @@
    "source": [
     "# create a list to collect epoch objects\n",
     "epochs = []\n",
+    "# start from pc_list[1:] to skip the reference epoch\n",
+    "# since enumerate starts from 0, use timestamps[e+1] to match the epochs with their timestamps\n",
     "for e, pc_file in enumerate(pc_list[1:]):\n",
     "    epoch_file = os.path.join(pc_dir, pc_file)\n",
     "    epoch = py4dgeo.read_from_las(epoch_file)\n",

--- a/course/module3/04_3d_timeseries_analysis/exercise/m3_theme4_exercise1_solution1.ipynb
+++ b/course/module3/04_3d_timeseries_analysis/exercise/m3_theme4_exercise1_solution1.ipynb
@@ -245,7 +245,7 @@
     "for e, pc_file in enumerate(pc_list[1:]):\n",
     "    epoch_file = os.path.join(pc_dir, pc_file)\n",
     "    epoch = py4dgeo.read_from_las(epoch_file)\n",
-    "    epoch.timestamp = timestamps[e]\n",
+    "    epoch.timestamp = timestamps[e+1]\n",
     "    epochs.append(epoch)\n",
     "\n",
     "# add epoch objects to the spatiotemporal analysis object\n",


### PR DESCRIPTION
Fixed an offset error in the point cloud time series processing loop. The code iterated through pc_list[1:] (skipping the reference epoch), but used timestamps[e], resulting in incorrect timestamp allocation.
This was fixed to [e+1], ensuring correct time alignment of point clouds and their timestamps in spatiotemporal analysis.