### PR TITLE
correct usage of normal_radii

### DIFF
--- a/course/module3/03_3d_change_analysis/03_3d_change_analysis.ipynb
+++ b/course/module3/03_3d_change_analysis/03_3d_change_analysis.ipynb
@@ -1024,7 +1024,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "id": "776553f4",
    "metadata": {},
    "outputs": [],
@@ -1032,7 +1032,7 @@
     "m3c2 = py4dgeo.M3C2(\n",
     "    epochs=(epoch_2009, epoch_2017),\n",
     "    corepoints=corepoints,\n",
-    "    normal_radii=(2.0, 1.0, 8.0),\n",
+    "    normal_radii = [r for r in range(2, 8 + 1)]  # result: [2, 3, 4, 5, 6, 7, 8]\n",
     "    cyl_radius=2.0,\n",
     "    max_distance=(50.0),\n",
     "    registration_error=(1.31)\n",

--- a/course/module3/06_casestudy_rockglacier/06_casestudy_rockglacier.ipynb
+++ b/course/module3/06_casestudy_rockglacier/06_casestudy_rockglacier.ipynb
@@ -113,18 +113,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[2026-03-01 15:55:02][INFO] Reading point cloud from file 'C:\\rsa\\Teaching\\25WS_VI_RemoteSensingTimeSeries\\module3_data\\ahk/ahk_2020_uls.laz'\n",
-      "[2026-03-01 15:55:07][INFO] Reading point cloud from file 'C:\\rsa\\Teaching\\25WS_VI_RemoteSensingTimeSeries\\module3_data\\ahk/ahk_2021_uls.laz'\n",
-      "[2026-03-01 15:55:16][INFO] Building KDTree structure with leaf parameter 10\n",
-      "[2026-03-01 15:55:34][INFO] Building KDTree structure with leaf parameter 10\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# load epochs into py4dgeo objects\n",
     "epoch2020 = py4dgeo.read_from_las(pc_file_2020)\n",

--- a/course/module3/06_casestudy_rockglacier/06_casestudy_rockglacier.ipynb
+++ b/course/module3/06_casestudy_rockglacier/06_casestudy_rockglacier.ipynb
@@ -66,7 +66,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -113,7 +113,18 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[2026-03-01 15:55:02][INFO] Reading point cloud from file 'C:\\rsa\\Teaching\\25WS_VI_RemoteSensingTimeSeries\\module3_data\\ahk/ahk_2020_uls.laz'\n",
+      "[2026-03-01 15:55:07][INFO] Reading point cloud from file 'C:\\rsa\\Teaching\\25WS_VI_RemoteSensingTimeSeries\\module3_data\\ahk/ahk_2021_uls.laz'\n",
+      "[2026-03-01 15:55:16][INFO] Building KDTree structure with leaf parameter 10\n",
+      "[2026-03-01 15:55:34][INFO] Building KDTree structure with leaf parameter 10\n"
+     ]
+    }
+   ],
    "source": [
     "# load epochs into py4dgeo objects\n",
     "epoch2020 = py4dgeo.read_from_las(pc_file_2020)\n",
@@ -126,7 +137,7 @@
     "m3c2 = py4dgeo.M3C2(\n",
     "    epochs=(epoch2020, epoch2021),\n",
     "    corepoints=corepoints,\n",
-    "    normal_radii=(4.0, 0.5, 6.0),\n",
+    "    normal_radii=[r / 2 for r in range(8, 12 + 1)], # result: [4.0, 4.5, 5.0, 5.5, 6.0]\n",
     "    cyl_radius=0.5,\n",
     "    max_distance=(15.0),\n",
     "    registration_error=0.037\n",
@@ -145,7 +156,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -433,7 +444,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "p4dgeo-doc",
    "language": "python",
    "name": "python3"
   },
@@ -447,12 +458,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.15"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "bca379f2a991149e96af4e280266aaefc3952de62153de79b5ea1b1512730db6"
-   }
+   "version": "3.11.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Corrected the code to reflect the intended range of M3C2 multi-scale capability in py4dgeo parametrization:
normal_radii=[r / 2 for r in range(8, 12 + 1)], # result: [4.0, 4.5, 5.0, 5.5, 6.0]