### PR TITLE
Remove ES6 polyfill from mkdocs configuration

### DIFF
--- a/mkdocs/mkdocs.yml
+++ b/mkdocs/mkdocs.yml
@@ -27,7 +27,6 @@ markdown_extensions:
   - pymdownx.arithmatex:
       generic: true
 extra_javascript:
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
   - assets/javascripts/quiz_evaluation.js
 


### PR DESCRIPTION
I noticed that the ETRAINEE Website is not available anymore and this popup appears.
<img width="1224" height="455" alt="grafik" src="https://github.com/user-attachments/assets/ac6b276a-bf26-49ab-8a38-1f980104a97e" />

After searching the web, I found out that polyfill is considered malware. With this PR, we are thus removing it ASAP from our website, hopefully before anyone has entered any credentials.

See for example: https://www.reddit.com/r/sysadmin/comments/1ttjp1i/suspicious_login_popup_from_polyfillio_on/

I assume this does not break anything, but even if, that would still be better than malware.